### PR TITLE
Bump version to 1.1.2, improve Visual Intelligence search errors

### DIFF
--- a/SortNAO.xcodeproj/project.pbxproj
+++ b/SortNAO.xcodeproj/project.pbxproj
@@ -308,7 +308,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SortNAO.SearchAction;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -340,7 +340,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SortNAO.SearchAction;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -508,7 +508,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SortNAO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -550,7 +550,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.SortNAO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/SortNAO/Intents/VisualIntelligenceSearch.swift
+++ b/SortNAO/Intents/VisualIntelligenceSearch.swift
@@ -121,25 +121,25 @@ struct SauceEntityQuery: EntityQuery {
 
 @available(iOS 26.0, *)
 private func renderErrorThumbnail(systemName: String, message: String) -> Data? {
-    let size = CGSize(width: 200, height: 200)
+    let size = CGSize(width: 280, height: 280)
     let renderer = UIGraphicsImageRenderer(size: size)
     let image = renderer.image { context in
         // Background
         UIColor.secondarySystemBackground.setFill()
         context.fill(CGRect(origin: .zero, size: size))
 
-        // Icon
-        let iconConfig = UIImage.SymbolConfiguration(pointSize: 48, weight: .medium)
+        // Icon (multicolor rendering)
+        let iconConfig = UIImage.SymbolConfiguration(pointSize: 56, weight: .medium)
+            .applying(UIImage.SymbolConfiguration.preferringMulticolor())
         if let icon = UIImage(systemName: systemName, withConfiguration: iconConfig) {
-            let tintedIcon = icon.withTintColor(.secondaryLabel, renderingMode: .alwaysOriginal)
-            let iconSize = tintedIcon.size
+            let iconSize = icon.size
             let iconRect = CGRect(
                 x: (size.width - iconSize.width) / 2,
-                y: 48 - iconSize.height / 2,
+                y: 68 - iconSize.height / 2,
                 width: iconSize.width,
                 height: iconSize.height
             )
-            tintedIcon.draw(in: iconRect)
+            icon.draw(in: iconRect)
         }
 
         // Text
@@ -147,11 +147,11 @@ private func renderErrorThumbnail(systemName: String, message: String) -> Data? 
         paragraphStyle.alignment = .center
         paragraphStyle.lineBreakMode = .byWordWrapping
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 13, weight: .medium),
+            .font: UIFont.systemFont(ofSize: 15, weight: .medium),
             .foregroundColor: UIColor.secondaryLabel,
             .paragraphStyle: paragraphStyle
         ]
-        let textRect = CGRect(x: 16, y: 100, width: size.width - 32, height: 84)
+        let textRect = CGRect(x: 20, y: 140, width: size.width - 40, height: 120)
         (message as NSString).draw(in: textRect, withAttributes: attributes)
     }
     return image.pngData()

--- a/SortNAO/Intents/VisualIntelligenceSearch.swift
+++ b/SortNAO/Intents/VisualIntelligenceSearch.swift
@@ -117,6 +117,46 @@ struct SauceEntityQuery: EntityQuery {
     }
 }
 
+// MARK: - Error Thumbnail Generation
+
+@available(iOS 26.0, *)
+private func renderErrorThumbnail(systemName: String, message: String) -> Data? {
+    let size = CGSize(width: 200, height: 200)
+    let renderer = UIGraphicsImageRenderer(size: size)
+    let image = renderer.image { context in
+        // Background
+        UIColor.secondarySystemBackground.setFill()
+        context.fill(CGRect(origin: .zero, size: size))
+
+        // Icon
+        let iconConfig = UIImage.SymbolConfiguration(pointSize: 48, weight: .medium)
+        if let icon = UIImage(systemName: systemName, withConfiguration: iconConfig) {
+            let tintedIcon = icon.withTintColor(.secondaryLabel, renderingMode: .alwaysOriginal)
+            let iconSize = tintedIcon.size
+            let iconRect = CGRect(
+                x: (size.width - iconSize.width) / 2,
+                y: 48 - iconSize.height / 2,
+                width: iconSize.width,
+                height: iconSize.height
+            )
+            tintedIcon.draw(in: iconRect)
+        }
+
+        // Text
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: UIColor.secondaryLabel,
+            .paragraphStyle: paragraphStyle
+        ]
+        let textRect = CGRect(x: 16, y: 100, width: size.width - 32, height: 84)
+        (message as NSString).draw(in: textRect, withAttributes: attributes)
+    }
+    return image.pngData()
+}
+
 // MARK: - Visual Intelligence Search Query
 
 @available(iOS 26.0, *)
@@ -124,12 +164,32 @@ struct SauceVisualSearchQuery: IntentValueQuery {
     // swiftlint:disable function_body_length
     func values(for input: SemanticContentDescriptor) async throws -> [SauceEntity] {
         guard let pixelBuffer = input.pixelBuffer else {
-            return []
+            let entity = SauceEntity(
+                id: "error-no-image",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "exclamationmark.triangle",
+                    message: NSLocalizedString("VisualIntelligence.Error.ImageProcessing", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
         }
 
         let keychain = Keychain(service: "com.tsubuzaki.SortNAO")
         guard let apiKey = try? keychain.get("SauceNAOAPIKey") else {
-            return []
+            let entity = SauceEntity(
+                id: "error-no-api-key",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "key.slash",
+                    message: NSLocalizedString("VisualIntelligence.Error.NoAPIKey", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
         }
 
         // Convert pixel buffer to JPEG inside withUnsafeBuffer for memory safety
@@ -140,7 +200,17 @@ struct SauceVisualSearchQuery: IntentValueQuery {
             let uiImage = UIImage(cgImage: cgImage)
             return uiImage.jpegData(compressionQuality: 0.9)
         }) else {
-            return []
+            let entity = SauceEntity(
+                id: "error-image-processing",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "exclamationmark.triangle",
+                    message: NSLocalizedString("VisualIntelligence.Error.ImageProcessing", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
         }
 
         // Build API request
@@ -152,7 +222,19 @@ struct SauceVisualSearchQuery: IntentValueQuery {
             URLQueryItem(name: "numres", value: "5")
         ]
 
-        guard let url = components.url else { return [] }
+        guard let url = components.url else {
+            let entity = SauceEntity(
+                id: "error-url",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "exclamationmark.triangle",
+                    message: NSLocalizedString("VisualIntelligence.Error.SearchFailed", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -174,8 +256,32 @@ struct SauceVisualSearchQuery: IntentValueQuery {
 
         request.httpBody = body
 
-        guard let (data, _) = try? await URLSession.shared.data(for: request) else { return [] }
-        guard let response = try? JSONDecoder().decode(SauceResponse.self, from: data) else { return [] }
+        guard let (data, _) = try? await URLSession.shared.data(for: request) else {
+            let entity = SauceEntity(
+                id: "error-network",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "wifi.exclamationmark",
+                    message: NSLocalizedString("VisualIntelligence.Error.SearchFailed", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
+        }
+        guard let response = try? JSONDecoder().decode(SauceResponse.self, from: data) else {
+            let entity = SauceEntity(
+                id: "error-decode",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "exclamationmark.triangle",
+                    message: NSLocalizedString("VisualIntelligence.Error.SearchFailed", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
+        }
 
         let sortedResults = response.results.sorted {
             (Double($0.header.similarity) ?? 0) > (Double($1.header.similarity) ?? 0)
@@ -206,7 +312,17 @@ struct SauceVisualSearchQuery: IntentValueQuery {
         }
 
         guard !entities.isEmpty else {
-            throw SortNAOIntentError.noResults
+            let entity = SauceEntity(
+                id: "error-no-results",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "magnifyingglass",
+                    message: NSLocalizedString("VisualIntelligence.Error.NoResults", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
         }
 
         await SauceEntityCache.shared.store(entities)
@@ -235,4 +351,3 @@ struct OpenSauceIntent: OpenIntent {
     }
 }
 #endif
-

--- a/SortNAO/Intents/VisualIntelligenceSearch.swift
+++ b/SortNAO/Intents/VisualIntelligenceSearch.swift
@@ -256,7 +256,7 @@ struct SauceVisualSearchQuery: IntentValueQuery {
 
         request.httpBody = body
 
-        guard let (data, _) = try? await URLSession.shared.data(for: request) else {
+        guard let (data, httpResponse) = try? await URLSession.shared.data(for: request) else {
             let entity = SauceEntity(
                 id: "error-network",
                 similarity: "0",
@@ -269,6 +269,21 @@ struct SauceVisualSearchQuery: IntentValueQuery {
             await SauceEntityCache.shared.store([entity])
             return [entity]
         }
+
+        if let statusCode = (httpResponse as? HTTPURLResponse)?.statusCode, statusCode == 429 {
+            let entity = SauceEntity(
+                id: "error-rate-limited",
+                similarity: "0",
+                sourceName: NSLocalizedString("VisualIntelligence.Error", comment: ""),
+                thumbnailData: renderErrorThumbnail(
+                    systemName: "hourglass",
+                    message: NSLocalizedString("VisualIntelligence.Error.RateLimited", comment: "")
+                )
+            )
+            await SauceEntityCache.shared.store([entity])
+            return [entity]
+        }
+
         guard let response = try? JSONDecoder().decode(SauceResponse.self, from: data) else {
             let entity = SauceEntity(
                 id: "error-decode",

--- a/SortNAO/Localizable.xcstrings
+++ b/SortNAO/Localizable.xcstrings
@@ -1470,6 +1470,23 @@
         }
       }
     },
+    "VisualIntelligence.Error.RateLimited" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rate limit reached.\nPlease wait a moment and try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レート制限に達しました。\nしばらく待ってからもう一度お試しください。"
+          }
+        }
+      }
+    },
     "VisualIntelligence.Error.SearchFailed" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SortNAO/Localizable.xcstrings
+++ b/SortNAO/Localizable.xcstrings
@@ -1402,6 +1402,91 @@
         }
       }
     },
+    "VisualIntelligence.Error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
+          }
+        }
+      }
+    },
+    "VisualIntelligence.Error.ImageProcessing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not process the image."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を処理できませんでした。"
+          }
+        }
+      }
+    },
+    "VisualIntelligence.Error.NoAPIKey" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No API key set.\nSet your SauceNAO API key in SortNAO."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APIキーが未設定です。\nSortNAOでSauceNAOのAPIキーを設定してください。"
+          }
+        }
+      }
+    },
+    "VisualIntelligence.Error.NoResults" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No matching sources found for this image."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この画像に一致するソースが見つかりませんでした。"
+          }
+        }
+      }
+    },
+    "VisualIntelligence.Error.SearchFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search failed.\nPlease try again."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索に失敗しました。\nもう一度お試しください。"
+          }
+        }
+      }
+    },
     "X" : {
       "localizations" : {
         "ja" : {


### PR DESCRIPTION
## Summary

- Bumps `MARKETING_VERSION` from 1.1.1 to 1.1.2 across all targets
- Visual Intelligence search now returns a descriptive error entity instead of empty results or throwing errors, so users always see feedback
- Error thumbnails are rendered offscreen using `UIGraphicsImageRenderer` (200x200) with an SF Symbol icon and localized message text
- Three distinct error states with unique icons:
  - **No API key** — `key.slash` icon with prompt to set API key in SortNAO
  - **No results** — `magnifyingglass` icon indicating no matching sources found
  - **Network/decode/image errors** — `wifi.exclamationmark` or `exclamationmark.triangle` icon with retry message
- Added localization strings (English + Japanese) for all new error messages

## Test plan

- [ ] Verify version shows 1.1.2 in app settings/About
- [ ] Test Visual Intelligence search with no API key set — should show key.slash thumbnail with "No API key" message
- [ ] Test Visual Intelligence search with valid API key on an image with no matches — should show magnifyingglass thumbnail with "No matching sources" message
- [ ] Test Visual Intelligence search with network disabled — should show wifi.exclamationmark thumbnail with "Search failed" message
- [ ] Test Visual Intelligence search with valid results — should work as before
- [ ] Verify Japanese localization displays correctly

https://claude.ai/code/session_01SZbKVDpePEfibLHbWVVoLM